### PR TITLE
Fix mutex destruction and waiter logic

### DIFF
--- a/rank03/philo/philo/srcs/clean.c
+++ b/rank03/philo/philo/srcs/clean.c
@@ -45,7 +45,8 @@ void	clean_table(t_table *t)
 	}
 	/* 전역 보호용 뮤텍스 파괴 */
 	pthread_mutex_destroy(&t->rules.mt_print);
-	pthread_mutex_destroy(&t->rules.mt_finish);
+        pthread_mutex_destroy(&t->rules.mt_finish);
+        pthread_mutex_destroy(&t->rules.mt_waiter);
 	/* 철학자 배열 해제 */
 	free(t->philos);
 }


### PR DESCRIPTION
## Summary
- destroy `mt_waiter` in cleanup
- guard `meals_eaten` updates with a mutex
- unlock waiter immediately after grabbing both forks
- adjust comments accordingly

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6840ea08f19c8332b473cd91fffad83c